### PR TITLE
Godot 4.7 support

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -8,9 +8,13 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="Stencil-Based Outline CompositorEffect"
 run/main_scene="uid://5q7qw3rqscd7"
-config/features=PackedStringArray("4.5", "Forward Plus")
+config/features=PackedStringArray("4.7", "Forward Plus")
 config/icon="res://icon.svg"

--- a/stencil_based_outline_compositor_effect/stencil_based_outilne_compositor_effect.gd
+++ b/stencil_based_outline_compositor_effect/stencil_based_outilne_compositor_effect.gd
@@ -493,7 +493,7 @@ func _render_callback(_p_effect_callback_type, p_render_data):
     @warning_ignore("integer_division")
     var y_groups : int = (resolution.y - 1) / 8 + 1
     var push_constant := PackedByteArray()
-    push_constant.resize(16) # Must be a multiple of 16 bytes
+    push_constant.resize(4) 
 
     # Run the jump-flood pipeline the required number of passes, swapping the
     # textures between each pass.
@@ -536,7 +536,7 @@ func _render_callback(_p_effect_callback_type, p_render_data):
     # construct the push constant for drawing our outlines.  It contains the
     # outline color, and the outline thickness squared
     var do_push_constant = PackedByteArray()
-    do_push_constant.resize(32)
+    do_push_constant.resize(20)
     do_push_constant.encode_float(0, outline_color.r)
     do_push_constant.encode_float(4, outline_color.g)
     do_push_constant.encode_float(8, outline_color.b)


### PR DESCRIPTION
Closes #5 

This fix makes the outline work with Godot 4.7 RC3.

<img width="2954" height="956" alt="fix" src="https://github.com/user-attachments/assets/dc3b07c7-ae99-4e93-b38c-70e951fabaa3" />
